### PR TITLE
Adding redirects=true to handle redirections. Example "Brewhouse" -> …

### DIFF
--- a/src/wikipedia.coffee
+++ b/src/wikipedia.coffee
@@ -39,6 +39,7 @@ module.exports = (robot) ->
             exintro: true
             explaintext: true
             format: 'json'
+            redirects: true
             prop: 'extracts'
             titles: res.match[1]
 


### PR DESCRIPTION
When searching for articles that redirect to other articles, the summary option prints no summary.

Adding redirects=true according to the API causes the API to follow redirects to the redirected article.

https://en.wikipedia.org/w/api.php?action=help&modules=query
